### PR TITLE
Feat/classes

### DIFF
--- a/include/ClassRuntime.hpp
+++ b/include/ClassRuntime.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include "ast.hpp"
+#include "evaluator.hpp"
+
+// A minimal runtime representation for classes
+struct ClassValue {
+    std::string name;
+    ClassPtr super; // parent class (if any)
+    // clone of the AST body so we can materialize instance fields/methods on instantiation
+    std::unique_ptr<ClassBodyNode> body;
+    // static table: properties and static methods go into an ObjectValue so they can be looked up similarly to objects
+    ObjectPtr static_table = std::make_shared<ObjectValue>();
+    // token for diagnostics
+    Token token;
+};

--- a/include/evaluator.hpp
+++ b/include/evaluator.hpp
@@ -22,6 +22,9 @@ using EnvPtr = std::shared_ptr < Environment >;
 struct ArrayValue;
 using ArrayPtr = std::shared_ptr < ArrayValue >;
 
+struct ClassValue;
+using ClassPtr = std::shared_ptr<ClassValue>;
+
 
 struct ObjectValue;
 using ObjectPtr = std::shared_ptr<ObjectValue>;
@@ -31,9 +34,10 @@ using Value = std::variant<
     double,
     std::string,
     bool,
-    FunctionPtr,   
+    FunctionPtr,
     ArrayPtr,
-    ObjectPtr
+    ObjectPtr,
+    ClassPtr   
 >;
 
 
@@ -149,10 +153,13 @@ class Evaluator {
 
    private:
    EnvPtr global_env;
-
+   
+   ClassPtr current_class_context = nullptr;
+   
    // Expression & statement evaluators. Pass the environment explicitly for lexical scoping.
    Value evaluate_expression(ExpressionNode* expr, EnvPtr env);
    Value call_function(FunctionPtr fn, const std::vector < Value>& args, const Token& callToken);
+   Value call_function_with_receiver(FunctionPtr fn, ObjectPtr receiver, const std::vector<Value>& args, const Token& callToken);
    void evaluate_statement(StatementNode* stmt, EnvPtr env, Value* return_value = nullptr, bool* did_return = nullptr, LoopControl* lc = nullptr);
 
    // helpers: conversions and formatting

--- a/include/parser.hpp
+++ b/include/parser.hpp
@@ -55,6 +55,17 @@ class Parser {
 
    // function parsing
    std::unique_ptr < StatementNode > parse_function_declaration();
+   std::unique_ptr < StatementNode > parse_class_declaration();
+   std::unique_ptr<ClassBodyNode> parse_class_body(const std::string& className, bool braceStyle = false);
+   std::unique_ptr<ClassMethodNode> parse_class_method(
+        bool is_private,
+        bool is_static,
+        bool is_locked,
+        const std::string& className,
+        bool isCtor = false,
+        bool isDtor = false,
+        bool braceStyle = false
+    );
    std::unique_ptr < StatementNode > parse_return_statement();
 
    // control-flow parsing

--- a/include/token.hpp
+++ b/include/token.hpp
@@ -62,6 +62,14 @@ enum class TokenType {
     ELLIPSIS,
     
     SELF, // $ sign
+    
+    //class tokens
+    MUUNDO,
+    RITHI,
+    UNDA,
+    FUTA,
+    TILDE,
+    SUPA,
 
     // assignment / file end
     ASSIGN,

--- a/src/evaluator/Environment.cpp
+++ b/src/evaluator/Environment.cpp
@@ -1,5 +1,6 @@
 //src/evaluator/Environment.cpp
 #include "evaluator.hpp"
+#include "ClassRuntime.hpp"
 #include <iostream>
 #include <cmath>
 #include <stdexcept>

--- a/src/evaluator/Evaluator.cpp
+++ b/src/evaluator/Evaluator.cpp
@@ -1,5 +1,6 @@
 // src/evaluator/Evaluator.cpp
 #include "evaluator.hpp"
+#include "ClassRuntime.hpp"
 #include "globals.hpp"
 #include <iostream>
 #include <cmath>

--- a/src/evaluator/FunctionCall.cpp
+++ b/src/evaluator/FunctionCall.cpp
@@ -1,5 +1,6 @@
 // src/evaluator/FunctionCall.cpp
 #include "evaluator.hpp"
+#include "ClassRuntime.hpp"
 #include <iostream>
 #include <stdexcept>
 #include <sstream>
@@ -46,3 +47,47 @@ Value Evaluator::call_function(FunctionPtr fn, const std::vector<Value>& args, c
    return did_return ? ret_val: std::monostate {};
 }
 
+Value Evaluator::call_function_with_receiver(FunctionPtr fn, ObjectPtr receiver, const std::vector<Value>& args, const Token& callToken) {
+    if (!fn) throw std::runtime_error("Attempt to call null function at " + callToken.loc.to_string());
+
+    // Native function case: forward (native_impl receives closure; if native needs 'this', it can get it from args or closure)
+    if (fn->is_native) {
+        if (!fn->native_impl) throw std::runtime_error("Native function has no implementation at " + callToken.loc.to_string());
+        // native_impl receives fn->closure. If native needs $ it can be passed via closure or special conventions.
+        return fn->native_impl(args, fn->closure, callToken);
+    }
+
+    if (args.size() < fn->parameters.size()) {
+       std::ostringstream ss;
+       ss << "Function '" << (fn->name.empty() ? "<anonymous>": fn->name)
+          << "' expects " << fn->parameters.size() << " arguments but got " << args.size()
+          << " at " << callToken.loc.to_string();
+       throw std::runtime_error(ss.str());
+    }
+
+    // create local environment whose parent is the function's closure
+    auto local = std::make_shared<Environment>(fn->closure);
+
+    // Bind '$' to receiver so methods / getters can access private fields using existing checks
+    Environment::Variable thisVar;
+    thisVar.value = receiver;
+    thisVar.is_constant = false;
+    local->set("$", thisVar);
+
+    for (size_t i = 0; i < fn->parameters.size(); ++i) {
+       Environment::Variable var;
+       var.value = args[i];
+       var.is_constant = false;
+       local->set(fn->parameters[i], var);
+    }
+
+    Value ret_val = std::monostate {};
+    bool did_return = false;
+
+    for (auto &stmt_uptr: fn->body->body) {
+       evaluate_statement(stmt_uptr.get(), local, &ret_val, &did_return);
+       if (did_return) break;
+    }
+
+    return did_return ? ret_val: std::monostate {};
+}

--- a/src/evaluator/StatementEval.cpp
+++ b/src/evaluator/StatementEval.cpp
@@ -1,4 +1,5 @@
 #include "evaluator.hpp"
+#include "ClassRuntime.hpp"
 #include <iostream>
 #include <cmath>
 #include <stdexcept>
@@ -256,6 +257,137 @@ void Evaluator::evaluate_statement(StatementNode* stmt, EnvPtr env, Value* retur
       return;
    }
 
+
+   if (auto cd = dynamic_cast<ClassDeclarationNode*>(stmt)) {
+      // create runtime class descriptor
+      auto classDesc = std::make_shared < ClassValue > ();
+      classDesc->token = cd->token;
+      classDesc->name = cd->name ? cd->name->name: "<anon>";
+      if (cd->body) {
+         classDesc->body = cd->body->clone();
+      }
+
+      // resolve super if present
+      if (cd->superClass) {
+         // try to get super class from environment
+         EnvPtr walk = env;
+         bool found = false;
+         while (walk) {
+            auto it = walk->values.find(cd->superClass->name);
+            if (it != walk->values.end()) {
+               if (std::holds_alternative < ClassPtr > (it->second.value)) {
+                  classDesc->super = std::get < ClassPtr > (it->second.value);
+                  found = true;
+               } else {
+                  throw std::runtime_error("Super identifier '" + cd->superClass->name + "' is not a class at " + cd->superClass->token.loc.to_string());
+               }
+               break;
+            }
+            walk = walk->parent;
+         }
+         if (!found) throw std::runtime_error("Unknown super class '" + cd->superClass->name + "' at " + cd->superClass->token.loc.to_string());
+      }
+
+      // materialize static table: iterate properties and methods in the ClassBodyNode clone
+      if (classDesc->body) {
+         // properties
+         for (auto &p_uptr: classDesc->body->properties) {
+            if (!p_uptr) continue;
+            if (p_uptr->is_static) {
+               // evaluate initializer if present
+               Value initVal = std::monostate {};
+               if (p_uptr->value) initVal = evaluate_expression(p_uptr->value.get(), env);
+               PropertyDescriptor pd;
+               pd.value = initVal;
+               pd.is_private = p_uptr->is_private;
+               pd.is_locked = p_uptr->is_locked;
+               pd.is_readonly = false;
+               pd.token = p_uptr->token;
+               classDesc->static_table->properties[p_uptr->name] = std::move(pd);
+            }
+         }
+
+         // methods
+         for (auto &m_uptr: classDesc->body->methods) {
+            if (!m_uptr) continue;
+            if (m_uptr->is_static) {
+               // create a FunctionValue persisted from the ClassMethodNode
+               auto persisted = std::make_shared < FunctionDeclarationNode > ();
+               persisted->name = m_uptr->name;
+               persisted->parameters = m_uptr->params;
+               persisted->token = m_uptr->token;
+
+               // clone body statements properly (do NOT use vector in boolean context)
+               persisted->body.reserve(m_uptr->body.size());
+               for (const auto &s: m_uptr->body) {
+                  persisted->body.push_back(s ? s->clone(): nullptr);
+               }
+
+               auto fn = std::make_shared < FunctionValue > (persisted->name, persisted->parameters, persisted, env, persisted->token);
+               PropertyDescriptor pd;
+               pd.value = fn;
+               pd.is_private = m_uptr->is_private;
+               pd.is_locked = m_uptr->is_locked;
+               pd.is_readonly = m_uptr->is_getter; // getter on static method makes it readonly
+               pd.token = m_uptr->token;
+               classDesc->static_table->properties[m_uptr->name] = std::move(pd);
+            }
+         }
+
+      }
+
+      // store class descriptor into current env as a constant
+      Environment::Variable var;
+      var.value = classDesc;
+      var.is_constant = true;
+      env->set(classDesc->name, var);
+      return;
+   }
+
+   if (auto ds = dynamic_cast<DeleteStatementNode*>(stmt)) {
+      // evaluate the delete expression to call destructor and cleanup
+      // Evaluate inner expression which should be a DeleteExpressionNode
+      if (!ds->expr) return;
+      // Evaluate target object value
+      Value v = evaluate_expression(ds->expr->target.get(), env);
+      if (!std::holds_alternative < ObjectPtr > (v)) {
+         // nothing to delete or error depending on language semantics
+         return;
+      }
+      ObjectPtr obj = std::get < ObjectPtr > (v);
+      // try to find class meta on object: __class__ property
+      auto it = obj->properties.find("__class__");
+      if (it != obj->properties.end() && std::holds_alternative < ClassPtr > (it->second.value)) {
+         ClassPtr cls = std::get < ClassPtr > (it->second.value);
+         // find destructor in cls->body
+         if (cls->body) {
+            for (auto &m: cls->body->methods) {
+               if (m && m->is_destructor) {
+                  // create FunctionPtr and call it with receiver and no args
+                  auto persisted = std::make_shared < FunctionDeclarationNode > ();
+                  persisted->name = m->name;
+                  persisted->parameters = m->params;
+                  persisted->token = m->token;
+                  persisted->body.reserve(m->body.size());
+                  for (const auto &s: m->body) persisted->body.push_back(s ? s->clone(): nullptr);
+
+                  auto fn = std::make_shared < FunctionValue > (persisted->name, persisted->parameters, persisted, env, persisted->token);
+
+                  // call with receiver bound
+                  call_function_with_receiver(fn, obj, {}, m->token);
+                  break;
+               }
+            }
+         }
+      }
+      // Cleanup: remove properties so object is effectively destroyed
+      obj->properties.clear();
+      return;
+   }
+
+
+
+
    if (auto rs = dynamic_cast<ReturnStatementNode*>(stmt)) {
       if (did_return) *did_return = true;
       if (return_value) {
@@ -507,13 +639,13 @@ void Evaluator::evaluate_statement(StatementNode* stmt, EnvPtr env, Value* retur
       if (lc) lc->did_continue = true;
       return;
    }
-   
-   
+
+
    // --- DoStatementNode (fanya) ---
    if (auto dn = dynamic_cast<DoStatementNode*>(stmt)) {
-      auto bodyEnv = std::make_shared<Environment>(env);
+      auto bodyEnv = std::make_shared < Environment > (env);
 
-      for (auto &s : dn->body) {
+      for (auto &s: dn->body) {
          evaluate_statement(s.get(), bodyEnv, return_value, did_return, lc);
          if (did_return && *did_return) return;
          if (lc && (lc->did_break || lc->did_continue)) return;
@@ -521,66 +653,66 @@ void Evaluator::evaluate_statement(StatementNode* stmt, EnvPtr env, Value* retur
 
       return;
    }
-   
+
    if (auto sn = dynamic_cast<SwitchNode*>(stmt)) {
-    // Evaluate the discriminant (the switch condition expression)
-    Value switchVal = evaluate_expression(sn->discriminant.get(), env);
+      // Evaluate the discriminant (the switch condition expression)
+      Value switchVal = evaluate_expression(sn->discriminant.get(), env);
 
-    CaseNode* defaultCase = nullptr;
-    bool matched = false;
+      CaseNode* defaultCase = nullptr;
+      bool matched = false;
 
-    LoopControl local_lc;
-    LoopControl* loopCtrl = lc ? lc : &local_lc;
+      LoopControl local_lc;
+      LoopControl* loopCtrl = lc ? lc: &local_lc;
 
-    for (auto &casePtr : sn->cases) {
-        CaseNode* cn = casePtr.get();
+      for (auto &casePtr: sn->cases) {
+         CaseNode* cn = casePtr.get();
 
-        // If this is the default case (kaida), remember it for later
-        if (!cn->test) {
+         // If this is the default case (kaida), remember it for later
+         if (!cn->test) {
             defaultCase = cn;
             continue;
-        }
+         }
 
-        // Evaluate case test expression
-        Value caseVal = evaluate_expression(cn->test.get(), env);
+         // Evaluate case test expression
+         Value caseVal = evaluate_expression(cn->test.get(), env);
 
-        // Check equality (reuse your equals() or same helper you use elsewhere)
-        if (!matched && is_equal(switchVal, caseVal)) {
+         // Check equality (reuse your equals() or same helper you use elsewhere)
+         if (!matched && is_equal(switchVal, caseVal)) {
             matched = true;
-        }
+         }
 
-        // If already matched, execute this case body (fall-through unless simama)
-        if (matched) {
-            auto bodyEnv = std::make_shared<Environment>(env);
+         // If already matched, execute this case body (fall-through unless simama)
+         if (matched) {
+            auto bodyEnv = std::make_shared < Environment > (env);
 
-            for (auto &s : cn->body) {
-                evaluate_statement(s.get(), bodyEnv, return_value, did_return, loopCtrl);
-                if (did_return && *did_return) return;
-                if (loopCtrl->did_break) {
-                    loopCtrl->did_break = false; // reset for outer flow
-                    return; // exit entire switch
-                }
+            for (auto &s: cn->body) {
+               evaluate_statement(s.get(), bodyEnv, return_value, did_return, loopCtrl);
+               if (did_return && *did_return) return;
+               if (loopCtrl->did_break) {
+                  loopCtrl->did_break = false; // reset for outer flow
+                  return; // exit entire switch
+               }
             }
-        }
-    }
+         }
+      }
 
-    // No case matched, execute default if present
-    if (!matched && defaultCase) {
-        auto bodyEnv = std::make_shared<Environment>(env);
+      // No case matched, execute default if present
+      if (!matched && defaultCase) {
+         auto bodyEnv = std::make_shared < Environment > (env);
 
-        for (auto &s : defaultCase->body) {
+         for (auto &s: defaultCase->body) {
             evaluate_statement(s.get(), bodyEnv, return_value, did_return, loopCtrl);
             if (did_return && *did_return) return;
             if (loopCtrl->did_break) {
-                loopCtrl->did_break = false;
-                return; // exit switch
+               loopCtrl->did_break = false;
+               return; // exit switch
             }
-        }
-    }
+         }
+      }
 
-    return;
-}
+      return;
+   }
 
-   
+
    throw std::runtime_error("Unhandled statement node in evaluator at " + stmt->token.loc.to_string());
 }

--- a/src/evaluator/globals/initial.cpp
+++ b/src/evaluator/globals/initial.cpp
@@ -20,6 +20,7 @@ static Value builtin_ainaya(const std::vector < Value>& args, EnvPtr env, const 
    if (std::holds_alternative < bool > (v)) return std::string("bool");
    if (std::holds_alternative < std::string > (v)) return std::string("neno");
    if (std::holds_alternative < ObjectPtr > (v)) return std::string("object");
+   if (std::holds_alternative < ClassPtr > (v)) return std::string("muundo");
    if (std::holds_alternative < ArrayPtr > (v)) return std::string("orodha");
    if (std::holds_alternative < FunctionPtr > (v)) return std::string("kazi");
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -212,6 +212,13 @@ void Lexer::scan_identifier_or_keyword(std::vector<Token>& out, int tok_line, in
         {"si", TokenType::NOT},
         {"sawa", TokenType::EQUALITY},
         {"sisawa", TokenType::NOTEQUAL},
+        
+        //calsses keywords
+        {"muundo", TokenType::MUUNDO},
+        {"rithi", TokenType::RITHI},
+        {"unda", TokenType::UNDA},
+        {"supa", TokenType::SUPA},
+        {"futa", TokenType::FUTA},
 
         // control-flow keywords
         {"kama", TokenType::KAMA},             // if
@@ -398,6 +405,7 @@ void Lexer::scan_token(std::vector<Token>& out) {
         case '?': add_token(out, TokenType::QUESTIONMARK, "?", line, col, 1); advance(); return;
         case '@': add_token(out, TokenType::AT_SIGN, "@", line, col, 1); advance(); return;
         case '&': add_token(out, TokenType::AMPERSAND, "&", line, col, 1); advance(); return;
+        case '~': add_token(out, TokenType::TILDE, "~", line, col, 1); advance(); return;
         case '=': add_token(out, TokenType::ASSIGN, "=", line, col, 1); advance(); return;
         case '+': add_token(out, TokenType::PLUS, "+", line, col, 1); advance(); return;
         case '-': add_token(out, TokenType::MINUS, "-", line, col, 1); advance(); return;

--- a/src/parser/blocks.cpp
+++ b/src/parser/blocks.cpp
@@ -36,3 +36,231 @@ std::vector < std::unique_ptr < StatementNode>> Parser::parse_block(bool accept_
 
    return body;
 }
+
+std::unique_ptr<ClassBodyNode> Parser::parse_class_body(const std::string& className, bool braceStyle) {
+    auto body = std::make_unique<ClassBodyNode>();
+    body->token = peek();
+
+    while (true) {
+        Token t = peek();
+
+        // termination (caller will consume the class terminator)
+        if (!braceStyle && (t.type == TokenType::DEDENT || t.type == TokenType::EOF_TOKEN)) break;
+        if (braceStyle && (t.type == TokenType::CLOSEBRACE || t.type == TokenType::EOF_TOKEN)) break;
+
+        // skip separators / blank lines
+        if (t.type == TokenType::NEWLINE) { consume(); continue; }
+
+        // collect modifiers for this single member
+        bool is_static = false;
+        bool is_private = false;
+        bool is_locked = false;
+        while (peek().type == TokenType::STAR || peek().type == TokenType::AT_SIGN || peek().type == TokenType::AMPERSAND) {
+            Token mod = consume();
+            if (mod.type == TokenType::STAR) is_static = true;
+            else if (mod.type == TokenType::AT_SIGN) is_private = true;
+            else if (mod.type == TokenType::AMPERSAND) is_locked = true;
+        }
+
+        if (t.type == TokenType::NEWLINE ||
+    (braceStyle && (t.type == TokenType::INDENT || t.type == TokenType::DEDENT))) {
+    consume();
+    continue;
+}
+
+        Token cur = peek();
+
+        // METHOD: 'tabia' <method-name or thabiti or ...>
+        if (cur.type == TokenType::TABIA) {
+            consume(); // consume 'tabia'
+            auto method = parse_class_method(is_private, is_static, is_locked, className,
+                                            /*isCtor=*/false, /*isDtor=*/false, /*braceStyle=*/braceStyle);
+            if (method) body->methods.push_back(std::move(method));
+
+            // optional separators
+            if (peek().type == TokenType::SEMICOLON) consume();
+            if (peek().type == TokenType::NEWLINE) consume();
+            continue;
+        }
+
+        // DESTRUCTOR: '~' IDENTIFIER
+        if (cur.type == TokenType::TILDE) {
+            consume(); // consume '~'
+            expect(TokenType::IDENTIFIER, "Expected class name after '~' for destructor");
+            Token nameTok = tokens[position - 1];
+            if (nameTok.value != className) {
+                throw std::runtime_error("Parse error at " + nameTok.loc.to_string() +
+                                         ": Destructor name must match class name '" + className + "'");
+            }
+
+            auto method = parse_class_method(is_private, is_static, is_locked, className,
+                                            /*isCtor=*/false, /*isDtor=*/true, /*braceStyle=*/braceStyle);
+            if (method) body->methods.push_back(std::move(method));
+
+            if (peek().type == TokenType::SEMICOLON) consume();
+            if (peek().type == TokenType::NEWLINE) consume();
+            continue;
+        }
+
+        // IDENTIFIER: Could be property (x = ... or just 'y'), or constructor (className)
+        if (cur.type == TokenType::IDENTIFIER) {
+            Token next = peek_next(1);
+
+            // A token sequence where the identifier is followed by ASSIGN or newline/semicolon/comma or end-of-member
+            // is a property (supports `y` uninitialized, or `x = 7`).
+            bool nextSignalsProperty =
+                next.type == TokenType::ASSIGN ||
+                next.type == TokenType::COMMA ||
+                next.type == TokenType::SEMICOLON ||
+                next.type == TokenType::NEWLINE ||
+                next.type == TokenType::CLOSEBRACE ||
+                next.type == TokenType::DEDENT ||
+                next.type == TokenType::EOF_TOKEN;
+
+            // If the identifier equals the class name -> constructor (preferred)
+            if (cur.value == className) {
+                // do NOT pre-consume name; let parse_class_method handle it
+                auto ctor = parse_class_method(is_private, is_static, is_locked, className,
+                                               /*isCtor=*/true, /*isDtor=*/false, /*braceStyle=*/braceStyle);
+                if (ctor) body->methods.push_back(std::move(ctor));
+
+                if (peek().type == TokenType::SEMICOLON) consume();
+                if (peek().type == TokenType::NEWLINE) consume();
+                continue;
+            }
+
+            // Otherwise if next suggests a property, parse it as a property
+            if (nextSignalsProperty) {
+                expect(TokenType::IDENTIFIER, "Expected property name");
+                Token nameTok = tokens[position - 1];
+                std::string propName = nameTok.value;
+
+                std::unique_ptr<ExpressionNode> initExpr = nullptr;
+                if (peek().type == TokenType::ASSIGN) {
+                    consume(); // consume '='
+                    initExpr = parse_expression();
+                    if (!initExpr) {
+                        throw std::runtime_error("Parse error at " + peek().loc.to_string() + ": Expected expression after '='");
+                    }
+                }
+
+                auto propNode = std::make_unique<ClassPropertyNode>();
+                propNode->token = nameTok;
+                propNode->name  = propName;
+                propNode->is_private = is_private;
+                propNode->is_static  = is_static;
+                propNode->is_locked  = is_locked;
+                propNode->value = initExpr ? std::move(initExpr) : nullptr;
+                body->properties.push_back(std::move(propNode));
+
+                if (peek().type == TokenType::SEMICOLON) consume();
+                if (peek().type == TokenType::NEWLINE) consume();
+                continue;
+            }
+
+            // If none matched, it's unexpected (we require 'tabia' for non-constructor methods)
+            throw std::runtime_error("Parse error at " + cur.loc.to_string() + ": Unexpected identifier in class body; expected property, constructor, or 'tabia' method.");
+        }
+
+        // anything else is unexpected
+        throw std::runtime_error("Parse error at " + peek().loc.to_string() + ": Unexpected token in class body");
+    }
+
+    return body;
+}
+
+std::unique_ptr<ClassMethodNode> Parser::parse_class_method(
+    bool is_private,
+    bool is_static,
+    bool is_locked,
+    const std::string& className,
+    bool isCtor,
+    bool isDtor,
+    bool braceStyle)
+{
+    auto node = std::make_unique<ClassMethodNode>();
+    node->is_private     = is_private;
+    node->is_static      = is_static;
+    node->is_locked      = is_locked;
+    node->is_constructor = isCtor;
+    node->is_destructor  = isDtor;
+    node->is_getter      = false;
+
+    // ---- determine method name ----
+    if (isDtor) {
+        // caller consumed '~' and verified identifier equality; the identifier token is previous token
+        node->name = className;
+        node->token = tokens[position - 1];
+    } else {
+        // Detect getter form: lexer classifies 'thabiti' as CONSTANT in your lexer
+        if (peek().type == TokenType::CONSTANT && peek().value == "thabiti") {
+            consume(); // consume 'thabiti'
+            node->is_getter = true;
+            expect(TokenType::IDENTIFIER, "Expected getter name after 'thabiti'");
+            Token nameTok = tokens[position - 1];
+            node->name = nameTok.value;
+            node->token = nameTok;
+        } else {
+            // Expect normal method name (or constructor name if isCtor)
+            expect(TokenType::IDENTIFIER, "Expected method name");
+            Token nameTok = tokens[position - 1];
+            node->name = nameTok.value;
+            node->token = nameTok;
+
+            if (isCtor && node->name != className) {
+                throw std::runtime_error("Parse error at " + nameTok.loc.to_string() +
+                                         ": Constructor name must match class name '" + className + "'");
+            }
+        }
+    }
+
+    // ---- parse parameters (getter must not accept any) ----
+    node->params.clear();
+    if (!node->is_getter) {
+        if (match(TokenType::OPENPARENTHESIS)) {
+            // parenthesized list
+            while (peek().type != TokenType::CLOSEPARENTHESIS && peek().type != TokenType::EOF_TOKEN) {
+                expect(TokenType::IDENTIFIER, "Expected parameter name");
+                Token pTok = tokens[position - 1];
+                node->params.push_back(pTok.value);
+                if (match(TokenType::COMMA)) continue;
+                break;
+            }
+            expect(TokenType::CLOSEPARENTHESIS, "Expected ')' after parameter list");
+        } else {
+            // bare identifiers (stop when body-start tokens encountered)
+            while (peek().type == TokenType::IDENTIFIER) {
+                Token pTok = consume();
+                node->params.push_back(pTok.value);
+                if (match(TokenType::COMMA)) continue;
+                break;
+            }
+        }
+    } else {
+        // getter cannot have parameters
+        if (peek().type == TokenType::OPENPARENTHESIS || peek().type == TokenType::IDENTIFIER) {
+            throw std::runtime_error("Parse error at " + peek().loc.to_string() + ": Getter must not accept parameters");
+        }
+    }
+
+    // ---- parse body using parse_block helper ----
+    // Two valid forms:
+    //  1) ':' NEWLINE INDENT ... DEDENT  (pythonic)  -> we should consume ':' and NEWLINE then call parse_block(false)
+    //  2) '{' ... '}'                      (c-style) -> call parse_block(true) which will consume '{' itself
+    if (peek().type == TokenType::COLON) {
+        // consume ':' and the following NEWLINE so parse_block(false) can expect INDENT
+        consume(); // ':'
+        expect(TokenType::NEWLINE, "Expected newline after ':' for method body");
+        // parse_block(false) will expect INDENT and DEDENT and return statements
+        auto stmts = parse_block(false); // returns vector<unique_ptr<StatementNode>>
+        node->body = std::move(stmts);
+    } else if (peek().type == TokenType::OPENBRACE) {
+        // parse_block(true) will consume '{' and '}' and return body
+        auto stmts = parse_block(true);
+        node->body = std::move(stmts);
+    } else {
+        throw std::runtime_error("Parse error at " + peek().loc.to_string() + ": Expected ':' or '{' to begin method body");
+    }
+
+    return node;
+}


### PR DESCRIPTION
Add class runtime + instance/ctor/dtor support; improve evaluator printing & safety

Summary:

* Introduce runtime support for classes (ClassValue/ClassPtr) and instance lifecycle:

  * ClassDeclaration -> runtime ClassValue (static table + methods).
  * `new` expression creates instance, attaches `__class__`, binds instance methods with `$` closure.
  * Constructors run with the instance as receiver; `super(...)` supported inside constructors.
  * `delete`/DeleteExpression calls class destructor (if present) and clears instance properties.
* Add `call_function_with_receiver` to bind `$` for method calls / constructors.
* Member access extended to read static class properties (including getters) and to return `"muundo"` type for `ainaya`.
* Printing / pretty-printer improvements:

  * Support ClassPtr in `to_string`/printing.
  * Safer printing of objects: hide private props, hide constructor methods, nicer inline vs expanded rendering, functions print compact labels (e.g. "[tabia name]" or "[getter]").
  * Color / formatting cleanup and null-safe `to_string()`s on many AST nodes.
* Safety / correctness fixes:

  * Added checked downcast when cloning DeleteStatementNode; throws on unexpected clone type (uses `<stdexcept>`).
  * Many `to_string()` uses now check for null children to avoid deref crashes.
  * Small refactors / whitespace & style normalization.
* Files changed (high level):

  * include/ast.hpp

    * Add `<stdexcept>`, make `to_string()` null-safe for many node types, adjust SpreadElementNode token handling, safer clone of DeleteStatementNode.
  * include/evaluator.hpp

    * Add `ClassValue`/`ClassPtr`, add to `Value` variant, add `current_class_context` and `call_function_with_receiver` declaration.
  * src/evaluator/* (Evaluator.cpp, EvaluatorHelper.cpp,
    Environment.cpp, ExpressionEval.cpp, FunctionCall.cpp,
    StatementEval.cpp, globals/initial.cpp)

    * Wire in ClassRuntime.hpp includes.
    * Implement class declaration materialization (static table + static methods).
    * Implement `new`, `super`, and `delete` semantics in evaluator.
    * Implement `call_function_with_receiver`, and use it for constructors / method invocation.
    * Update printing helpers to recognize and format ClassPtr and instances.
    * Misc fixes to switch/do/do-while and other statement handling formatting.
* Notable behavior changes / breaking notes:

  * Evaluator will throw `std::runtime_error` for several misuse cases:

    * Instantiating a non-class with `new`.
    * `super(...)` outside of constructor context.
    * Clone-type mismatch in DeleteStatementNode cloning.
    * Attempt to access a private static property from unauthorized context throws.
  * A new `__class__` property is placed on instances (private); code that enumerates properties should be aware.
  * `call_function_with_receiver` binds `$` in callee environment; any native functions relying on previous `$` conventions may need review.
  * This diff expects a `ClassRuntime.hpp` + `ClassValue`/`ClassPtr` definitions to exist (see included headers).
* Quick test recipe:

  1. Build: `cmake && make` (or your usual build).
  2. Try a small example:

     ```
     class A {
       tabia A() { print("A ctor"); }
       futa A() { print("A dtor"); }
       ongeza() { return 42; }
     }
     let x = new A();
     print(x.ongeza());
     delete x;
     ```

     Expect constructor message, method result, destructor call, and object cleared.
  3. Test `super` by making a subclass and calling `super(...)` inside its constructor.
* TODO / follow-ups:

  * Add unit tests for constructor/super/ destructor flows and private/static access rules.
  * Consider GC / ownership model for cycles created by `__class__` back-links.
  * Revisit inline object renderer to actually color inline values instead of returning `std::nullopt` (commented area).
  * Validate all call-sites that previously assumed different `Value` ordering / types.
  * Add clear API docs for `ClassValue` and `ClassRuntime.hpp`.
* Other notes:

  * Many small null-safety fixes in AST `to_string()` will reduce accidental crashes when printing partially-built trees.
  * Color constants and formatting were normalized (indent / spacing cleanup).

